### PR TITLE
feat: provenance, ZWNJ hygiene, address fields (v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ No unreleased changes yet.
 
 ---
 
+## [1.4.0] - 2026-09-10
+
+### Added
+
+- `DATA_PROVENANCE.md` — documents source status, rebuild pipeline, pool sizes
+  by release, and CI data-quality gates.
+- `normalize_zwnj` / `apply_zwnj_policy` in `farsi_faker.cleaning` for
+  ZWNJ (نیم‌فاصله) hygiene on inputs and selected lexical compounds.
+- Address generation in `farsi_faker.profile`:
+  - `iranian_cities`, `city_name`, `street_name`, `address_record`
+  - `profile()` / `profile_record` now include `city`, `street`, `alley`, `plaque`
+
+### Changed
+
+- ZWNJ normalization is wired into `precision_repair`; embedded pool sizes
+  unchanged (7493 / 3648 / 5748).
+
+---
+
 ## [1.3.0] - 2026-09-10
 
 ### Added
@@ -241,11 +260,16 @@ This project follows [Semantic Versioning](https://semver.org/):
 - [x] Postal code generation
 - [x] CLI with JSON/CSV output
 
-### Planned for 1.4.0
+### Completed in 1.4.0
 
-- [ ] Restore source CSVs or documented rebuild provenance
-- [ ] Optional ZWNJ-normalized rebuild from original sources
-- [ ] Address / city generation
+- [x] Data provenance documentation (`DATA_PROVENANCE.md`)
+- [x] ZWNJ hygiene helpers wired into the cleaning pipeline
+- [x] Address / city generation
+
+### Planned for 1.5.0
+
+- [ ] Restore raw CSV sources when available and document a from-source rebuild
+- [ ] Optional weighted sampling by name frequency
 
 ---
 
@@ -255,10 +279,12 @@ This project follows [Semantic Versioning](https://semver.org/):
 - **PyPI:** https://pypi.org/project/farsi-faker/
 - **Issues:** https://github.com/alisadeghiaghili/farsi-faker/issues
 - **Changelog:** https://github.com/alisadeghiaghili/farsi-faker/releases
+- **Data provenance:** [DATA_PROVENANCE.md](DATA_PROVENANCE.md)
 
 ---
 
-[Unreleased]: https://github.com/alisadeghiaghili/farsi-faker/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/alisadeghiaghili/farsi-faker/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/alisadeghiaghili/farsi-faker/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/alisadeghiaghili/farsi-faker/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/alisadeghiaghili/farsi-faker/compare/v1.1.1...v1.2.0
 [1.1.1]: https://github.com/alisadeghiaghili/farsi-faker/compare/v1.1.0...v1.1.1

--- a/DATA_PROVENANCE.md
+++ b/DATA_PROVENANCE.md
@@ -1,0 +1,76 @@
+# Data Provenance — farsi-faker
+
+This document describes how the embedded name database
+(`farsi_faker/data/names.pkl`) is produced and what guarantees the test
+suite enforces on every release.
+
+## Source status
+
+| Item | Status |
+|------|--------|
+| Original CSV sources (`data_sources/iranianNamesDataset.csv`, `iranian-surname-frequencies.csv`) | **Not in the repository** (removed before v1.0.0 public history was curated) |
+| Rebuild path from raw CSVs | **Unavailable** until sources are restored |
+| Current artifact | Deterministically cleaned from the previously shipped pickle |
+
+Until raw sources are restored, the **authoritative** rebuild input is the
+last released `names.pkl`, processed by `farsi_faker.cleaning` /
+`scripts/rebuild_names_pkl.py`.
+
+## Pipeline (as of v1.4.0)
+
+1. Load `names.pkl` (`male_names`, `female_names`, `last_names`).
+2. `precision_repair()` per name:
+   - `join_ocr_splits` — singleton tokens (`آ رمان`) and short-head splits (`آر مان`)
+   - `join_abdol_family` — glue `عبد` / `عب` compounds (`عبد الله` → `عبدالله`)
+   - `normalize_zwnj` — strip ZWNJ–space hybrids and edge ZWNJ
+   - drop truncated `ال` endings and bare prefixes (`عبد`, `آق`, …)
+   - drop names with fewer than 3 letters after compaction
+   - drop gender-label noise (female honorifics in the male pool, …)
+3. Resolve male/female overlaps (keep female side).
+4. Sort, unique, write pickle (protocol HIGHEST).
+
+Rebuild command:
+
+```bash
+python scripts/rebuild_names_pkl.py --dry-run
+python scripts/rebuild_names_pkl.py
+```
+
+## Pool sizes by release
+
+| Release | male | female | last | notes |
+|---------|-----:|-------:|-----:|-------|
+| ≤1.1.1 | 7863 | 3817 | 5755 | pre-cleaning |
+| 1.2.0 | 7633 | 3730 | 5755 | OCR singleton + honorific pass |
+| 1.3.0 | 7493 | 3648 | 5748 | Abdol glue + truncated tokens |
+| 1.4.0 | 7493 | 3648 | 5748 | ZWNJ hygiene (no size change expected) |
+
+Exact numbers after each rebuild are printed by `rebuild_names_pkl.py`.
+
+## CI gates
+
+`tests/test_data_quality.py` fails the build if any of the following
+reappear in the embedded pickle:
+
+- singleton-token OCR artifacts
+- female honorifics in the male pool / male titles leading female names
+- gender pool overlap
+- unsorted or duplicate pools
+- empty / double-space names
+- truncated `ال` endings
+- unglued bare `عبد` / `عب`
+- names shorter than 3 letters
+
+## Profile field provenance
+
+Synthetic contact fields (`national_id`, `mobile`, `email`, `postal_code`,
+`city`, `street`, `alley`, `plaque`) are **generated**, not scraped from
+real people:
+
+- National ID uses the official Iranian 10-digit checksum.
+- Mobile numbers use real operator *prefixes* with random suffixes.
+- Emails romanize generated Persian names.
+- Cities/street labels are drawn from a built-in list of major Iranian
+  cities and common street names.
+
+They are for test fixtures only.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include LICENSE
 include CHANGELOG.md
 include CONTRIBUTING.md
 include API_REFERENCE.md
+include DATA_PROVENANCE.md
 
 # Include package configuration
 include setup.py

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@
 
 - **Embedded name database** — Persian first and family names shipped with the package
 - **Gender-specific generation** — separate male and female first-name pools
-- **Profile fields** — national ID (کد ملی with checksum), mobile, email, postal code
+- **Profile fields** — national ID (کد ملی with checksum), mobile, email, postal code, address
 - **CLI** — `python -m farsi_faker` for JSON/CSV fixtures
 - **Fast cold start** — pickle-backed name cache, shared across instances
 - **Reproducible** — seed support for stable fixtures
@@ -55,11 +55,10 @@
 - **Tested** — unit, packaging, concurrency, profile, and data-quality gates in CI
 - **Unicode** — Persian/Farsi text output
 - **Optional pandas** — DataFrame output for data-science workflows
-- **Cleaning helpers** — `farsi_faker.cleaning` for OCR-split repair on your own lists
+- **Cleaning helpers** — `farsi_faker.cleaning` for OCR-split and ZWNJ repair
 
-> **Data quality (v1.3.0+):** the embedded database was precision-rebuilt
-> (OCR joins, Abdol glue, truncated-token removal). Multi-word surnames and
-> legitimate compound first names are preserved. Treat generated names as
+> **Data provenance:** see [DATA_PROVENANCE.md](DATA_PROVENANCE.md) for how the
+> embedded name pools are cleaned and gated in CI. Treat generated names as
 > fixtures, not as a validated onomastics resource.
 
 ---

--- a/farsi_faker/__init__.py
+++ b/farsi_faker/__init__.py
@@ -11,7 +11,7 @@ Features:
     - Zero required runtime dependencies
     - PEP 561 typed package (``py.typed``)
     - Name-pool cleaning helpers (``farsi_faker.cleaning``)
-    - Synthetic profile fields: national ID, mobile, email, postal code
+    - Synthetic profile fields: national ID, mobile, email, postal code, address
     - CLI: ``python -m farsi_faker``
 
 Quick Start:
@@ -33,16 +33,20 @@ from ._version import (
     __version_info__,
     check_version,
 )
-from .cleaning import clean_name_pools, join_ocr_splits
+from .cleaning import apply_zwnj_policy, clean_name_pools, join_ocr_splits, normalize_zwnj
 from .faker import FarsiFaker, generate_fake_name
 from .profile import (
+    address_record,
+    city_name,
     email_address,
+    iranian_cities,
     is_valid_mobile,
     is_valid_national_id,
     mobile_number,
     national_id,
     postal_code,
     profile_record,
+    street_name,
 )
 
 __all__ = [
@@ -50,12 +54,18 @@ __all__ = [
     'generate_fake_name',
     'clean_name_pools',
     'join_ocr_splits',
+    'normalize_zwnj',
+    'apply_zwnj_policy',
     'national_id',
     'is_valid_national_id',
     'mobile_number',
     'is_valid_mobile',
     'email_address',
     'postal_code',
+    'iranian_cities',
+    'city_name',
+    'street_name',
+    'address_record',
     'profile_record',
     '__version__',
     '__version_info__',

--- a/farsi_faker/_version.py
+++ b/farsi_faker/_version.py
@@ -28,7 +28,7 @@ Attributes:
 
 from typing import Optional
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 __version_info__ = tuple(int(i) for i in __version__.split('.') if i.isdigit())
 
 # Version components for programmatic access
@@ -42,7 +42,7 @@ __status__ = "Production/Stable"
 
 # Release information
 __release_date__ = "2026-09-10"
-__release_name__ = "Profile Fields"
+__release_name__ = "Address & Provenance"
 
 # Package metadata
 __author__ = "Ali Sadeghi Aghili"
@@ -147,6 +147,17 @@ def check_version(required_version: str) -> bool:
 
 
 VERSION_HISTORY = {
+    "1.4.0": {
+        "date": "2026-09-10",
+        "status": "stable",
+        "changes": [
+            "Add DATA_PROVENANCE.md documenting source status and rebuild pipeline",
+            "Add normalize_zwnj / apply_zwnj_policy for ZWNJ hygiene",
+            "Wire ZWNJ normalization into precision_repair",
+            "Add iranian_cities, city_name, street_name, address_record",
+            "Extend profile() / profile_record with city, street, alley, plaque",
+        ],
+    },
     "1.3.0": {
         "date": "2026-09-10",
         "status": "stable",

--- a/farsi_faker/cleaning.py
+++ b/farsi_faker/cleaning.py
@@ -22,10 +22,13 @@ Example:
 
 from __future__ import annotations
 
+import re
 from typing import Dict, Iterable, List, Mapping, Optional, Sequence
 
 __all__ = [
     'normalize_name',
+    'normalize_zwnj',
+    'apply_zwnj_policy',
     'has_singleton_token',
     'join_ocr_splits',
     'join_abdol_family',
@@ -84,6 +87,96 @@ def normalize_name(name: Optional[str]) -> str:
     if name is None:
         return ''
     return ' '.join(str(name).split())
+
+
+ZWNJ = '‌'
+
+# Space-separated compounds that take a ZWNJ (نیم‌فاصله) in modern orthography.
+# Keep this list conservative: only high-confidence lexical pairs, not names.
+_ZWNJ_COMPOUNDS = frozenset(
+    {
+        ('می', 'خواهد'),
+        ('می', 'رود'),
+        ('می', 'آید'),
+        ('می', 'دهد'),
+        ('می', 'گوید'),
+        ('می', 'بیند'),
+        ('می', 'شود'),
+        ('می', 'تواند'),
+        ('خانه', 'دار'),
+        ('کتاب', 'خانه'),
+        ('مدرسه', 'رو'),
+    }
+)
+
+
+def normalize_zwnj(name: Optional[str]) -> str:
+    """Clean ZWNJ placement around spaces and at string edges.
+
+    Removes spaces that sit next to a ZWNJ and strips leading/trailing ZWNJ.
+    Internal ZWNJ characters are preserved.
+
+    Args:
+        name (str, optional): Raw or normalized name.
+
+    Returns:
+        str: ZWNJ-hygienic string; empty when input is blank.
+
+    Example:
+        >>> normalize_zwnj('می‌ رود')
+        'می‌رود'
+        >>> normalize_zwnj('‌علی‌')
+        'علی'
+        >>> normalize_zwnj('می‌رود')
+        'می‌رود'
+    """
+    if name is None:
+        return ''
+    text = str(name)
+    # Drop spaces that abut ZWNJ.
+    text = re.sub(rf'{ZWNJ}\s+', ZWNJ, text)
+    text = re.sub(rf'\s+{ZWNJ}', ZWNJ, text)
+    # Strip ZWNJ at edges.
+    text = text.strip(ZWNJ)
+    return text
+
+
+def apply_zwnj_policy(name: str) -> str:
+    """Rewrite known space-separated compounds using ZWNJ.
+
+    Only pairs listed in the internal compound set are rewritten. Person
+    names such as ``محمد رضا`` are left unchanged.
+
+    Args:
+        name (str): Name already whitespace-normalized.
+
+    Returns:
+        str: Name with selected compounds joined by ZWNJ.
+
+    Example:
+        >>> apply_zwnj_policy('می خواهد')
+        'می‌خواهد'
+        >>> apply_zwnj_policy('محمد رضا')
+        'محمد رضا'
+    """
+    normalized = normalize_zwnj(normalize_name(name))
+    if not normalized:
+        return ''
+
+    tokens = _tokens(normalized)
+    if len(tokens) < 2:
+        return normalized
+
+    result: List[str] = [tokens[0]]
+    index = 1
+    while index < len(tokens):
+        pair = (result[-1], tokens[index])
+        if pair in _ZWNJ_COMPOUNDS:
+            result[-1] = result[-1] + ZWNJ + tokens[index]
+        else:
+            result.append(tokens[index])
+        index += 1
+    return ' '.join(result)
 
 
 def _tokens(name: str) -> List[str]:
@@ -283,9 +376,10 @@ def precision_repair(name: str, *, pool_gender: str) -> Optional[str]:
 
     1. :func:`join_ocr_splits` (singleton / short-head splits)
     2. :func:`join_abdol_family`
-    3. Drop if :func:`is_truncated_name`
-    4. Drop if :func:`is_too_short`
-    5. Drop if :func:`drop_from_pool` flags gender-label noise
+    3. :func:`normalize_zwnj`
+    4. Drop if :func:`is_truncated_name`
+    5. Drop if :func:`is_too_short`
+    6. Drop if :func:`drop_from_pool` flags gender-label noise
 
     Args:
         name (str): Raw name.
@@ -305,7 +399,7 @@ def precision_repair(name: str, *, pool_gender: str) -> Optional[str]:
         >>> precision_repair('آرش', pool_gender='male')
         'آرش'
     """
-    repaired = join_abdol_family(join_ocr_splits(name))
+    repaired = normalize_zwnj(join_abdol_family(join_ocr_splits(name)))
     if not repaired:
         return None
     if repaired in _INCOMPLETE_STANDALONE:

--- a/farsi_faker/faker.py
+++ b/farsi_faker/faker.py
@@ -698,10 +698,11 @@ class FarsiFaker:
         return _generate(rng=self._random)
 
     def profile(self, gender: GenderInput = None) -> Dict[str, str]:
-        """Return a full synthetic person record with contact fields.
+        """Return a full synthetic person record with contact and address fields.
 
-        Combines :meth:`full_name` with national ID, mobile, email, and
-        postal code. All fields share this instance's RNG stream.
+        Combines :meth:`full_name` with national ID, mobile, email, postal
+        code, city, street, alley, and plaque. All fields share this
+        instance's RNG stream.
 
         Args:
             gender (str, optional): Desired gender token.
@@ -709,7 +710,7 @@ class FarsiFaker:
         Returns:
             Dict[str, str]: Keys ``name``, ``first_name``, ``last_name``,
             ``gender``, ``national_id``, ``mobile``, ``email``,
-            ``postal_code``.
+            ``postal_code``, ``city``, ``street``, ``alley``, ``plaque``.
 
         Example::
             >>> faker = FarsiFaker(seed=42)
@@ -718,8 +719,10 @@ class FarsiFaker:
             'male'
             >>> '@' in person['email']
             True
+            >>> person['city']
+            '...'
         """
-        from .profile import email_address
+        from .profile import address_record, email_address
 
         base = self.full_name(gender)
         nid = self.national_id()
@@ -730,6 +733,7 @@ class FarsiFaker:
             rng=self._random,
         )
         postal = self.postal_code()
+        address = address_record(rng=self._random, postal_code_value=postal)
 
         return {
             **base,
@@ -737,6 +741,10 @@ class FarsiFaker:
             'mobile': mobile,
             'email': email,
             'postal_code': postal,
+            'city': address['city'],
+            'street': address['street'],
+            'alley': address['alley'],
+            'plaque': address['plaque'],
         }
 
 

--- a/farsi_faker/profile.py
+++ b/farsi_faker/profile.py
@@ -26,6 +26,10 @@ __all__ = [
     'is_valid_mobile',
     'email_address',
     'postal_code',
+    'iranian_cities',
+    'city_name',
+    'street_name',
+    'address_record',
     'profile_record',
 ]
 
@@ -323,6 +327,8 @@ def profile_record(
     generator = random.Random(seed)
     faker = FarsiFaker(seed=generator.randint(0, 2**32 - 1))
     person = faker.full_name(gender)
+    post = postal_code(rng=generator)
+    address = address_record(rng=generator, postal_code_value=post)
 
     return {
         **person,
@@ -333,5 +339,169 @@ def profile_record(
             last_name=person['last_name'],
             rng=generator,
         ),
-        'postal_code': postal_code(rng=generator),
+        'postal_code': post,
+        'city': address['city'],
+        'street': address['street'],
+        'alley': address['alley'],
+        'plaque': address['plaque'],
+    }
+
+
+# ---------------------------------------------------------------------------
+# City / address
+# ---------------------------------------------------------------------------
+
+_IRANIAN_CITIES: tuple = (
+    'تهران',
+    'مشهد',
+    'اصفهان',
+    'کرج',
+    'شیراز',
+    'تبریز',
+    'قم',
+    'اهواز',
+    'کرمانشاه',
+    'ارومیه',
+    'رشت',
+    'زاهدان',
+    'همدان',
+    'کرمان',
+    'یزد',
+    'اردبیل',
+    'بندرعباس',
+    'اراک',
+    'اسلامشهر',
+    'زنجان',
+    'سنندج',
+    'قزوین',
+    'خرم‌آباد',
+    'گرگان',
+    'ساری',
+    'بیرجند',
+    'بوشهر',
+    'بجنورد',
+    'ایلام',
+    'شهرکرد',
+)
+
+_STREET_PREFIXES = (
+    'خیابان',
+    'بلوار',
+    'کوچه',
+)
+
+_STREET_NAMES = (
+    'ولیعصر',
+    'آزادی',
+    'انقلاب',
+    'امام حسین',
+    'فردوسی',
+    'حافظ',
+    'سعادت‌آباد',
+    'نیاوران',
+    'پاسداران',
+    'مدرس',
+    'جمهوری',
+    'طالقانی',
+    'کارگر',
+    'شیخ بهایی',
+    'میرداماد',
+    'اشرفی اصفهانی',
+    'چمران',
+    'همت',
+    'نواب',
+    'ستارخان',
+)
+
+_ALLEY_PREFIXES = (
+    'کوچه',
+    'بن‌بست',
+    'کوی',
+)
+
+
+def iranian_cities() -> tuple:
+    """Return the built-in pool of major Iranian city names.
+
+    Returns:
+        tuple: Persian city names (immutable).
+
+    Example:
+        >>> 'تهران' in iranian_cities()
+        True
+    """
+    return _IRANIAN_CITIES
+
+
+def city_name(rng: Optional[random.Random] = None) -> str:
+    """Pick a random Iranian city.
+
+    Args:
+        rng (random.Random, optional): Seeded RNG for reproducibility.
+
+    Returns:
+        str: A city name from :func:`iranian_cities`.
+
+    Raises:
+        TypeError: If *rng* is not a ``random.Random``.
+
+    Example:
+        >>> city_name() in iranian_cities()
+        True
+    """
+    generator = _require_random(rng)
+    return generator.choice(_IRANIAN_CITIES)
+
+
+def street_name(rng: Optional[random.Random] = None) -> str:
+    """Build a synthetic Persian street label.
+
+    Args:
+        rng (random.Random, optional): Seeded RNG for reproducibility.
+
+    Returns:
+        str: e.g. ``'خیابان ولیعصر'``.
+
+    Example:
+        >>> street_name().startswith(('خیابان', 'بلوار', 'کوچه'))
+        True
+    """
+    generator = _require_random(rng)
+    prefix = generator.choice(_STREET_PREFIXES)
+    name = generator.choice(_STREET_NAMES)
+    return f'{prefix} {name}'
+
+
+def address_record(
+    rng: Optional[random.Random] = None,
+    *,
+    postal_code_value: Optional[str] = None,
+) -> Dict[str, str]:
+    """Build a synthetic Iranian address block.
+
+    Args:
+        rng (random.Random, optional): Seeded RNG for reproducibility.
+        postal_code_value (str, optional): Reuse an existing postal code
+            instead of generating a new one.
+
+    Returns:
+        Dict[str, str]: Keys ``city``, ``street``, ``alley``, ``plaque``,
+        ``postal_code``.
+
+    Example:
+        >>> addr = address_record()
+        >>> addr['city'] in iranian_cities()
+        True
+        >>> len(addr['postal_code'])
+        10
+    """
+    generator = _require_random(rng)
+    alley_prefix = generator.choice(_ALLEY_PREFIXES)
+    alley_name = generator.choice(_STREET_NAMES)
+    return {
+        'city': city_name(rng=generator),
+        'street': street_name(rng=generator),
+        'alley': f'{alley_prefix} {alley_name}',
+        'plaque': str(generator.randint(1, 200)),
+        'postal_code': postal_code_value or postal_code(rng=generator),
     }

--- a/tests/test_address_zwnj.py
+++ b/tests/test_address_zwnj.py
@@ -1,0 +1,92 @@
+"""TDD specs for ZWNJ normalization and address/city generators."""
+
+from __future__ import annotations
+
+import random
+import re
+
+from farsi_faker.cleaning import normalize_zwnj, apply_zwnj_policy
+from farsi_faker.profile import (
+    address_record,
+    city_name,
+    iranian_cities,
+    street_name,
+)
+
+
+class TestNormalizeZwnj:
+    """ZWNJ / space hygiene."""
+
+    def test_collapses_zwnj_beside_space(self) -> None:
+        # Space around ZWNJ should not leave double separators.
+        assert normalize_zwnj("می‌ رود") == "می‌رود"
+        assert normalize_zwnj("می ‌رود") == "می‌رود"
+
+    def test_strips_leading_trailing_zwnj(self) -> None:
+        assert normalize_zwnj("‌علی‌") == "علی"
+
+    def test_preserves_internal_zwnj(self) -> None:
+        assert normalize_zwnj("می‌رود") == "می‌رود"
+
+    def test_empty(self) -> None:
+        assert normalize_zwnj("") == ""
+        assert normalize_zwnj(None) == ""  # type: ignore[arg-type]
+
+
+class TestApplyZwnjPolicy:
+    """Convert selected space-separated compounds to ZWNJ form."""
+
+    def test_known_compounds_get_zwnj(self) -> None:
+        assert apply_zwnj_policy("می خواهد") == "می‌خواهد"
+        assert apply_zwnj_policy("خانه دار") == "خانه‌دار"
+
+    def test_unknown_compounds_untouched(self) -> None:
+        assert apply_zwnj_policy("محمد رضا") == "محمد رضا"
+        assert apply_zwnj_policy("علی") == "علی"
+
+    def test_empty(self) -> None:
+        assert apply_zwnj_policy("") == ""
+
+
+class TestCities:
+    """Iranian city pool."""
+
+    def test_contains_major_cities(self) -> None:
+        cities = iranian_cities()
+        assert "تهران" in cities
+        assert "مشهد" in cities
+        assert "اصفهان" in cities
+        assert "شیراز" in cities
+        assert "تبریز" in cities
+
+    def test_size_reasonable(self) -> None:
+        assert len(iranian_cities()) >= 20
+
+    def test_city_name_uses_pool(self) -> None:
+        assert city_name() in iranian_cities()
+
+    def test_city_name_reproducible(self) -> None:
+        a = city_name(rng=random.Random(5))
+        b = city_name(rng=random.Random(5))
+        assert a == b
+
+
+class TestAddress:
+    """Street and full address records."""
+
+    def test_street_format(self) -> None:
+        street = street_name()
+        assert street
+        assert isinstance(street, str)
+
+    def test_address_record_keys(self) -> None:
+        addr = address_record(rng=random.Random(1))
+        assert {"city", "street", "alley", "plaque", "postal_code"}.issubset(addr.keys())
+        assert addr["city"] in iranian_cities()
+        assert re.fullmatch(r"\d{10}", addr["postal_code"])
+        assert addr["plaque"].isdigit()
+
+    def test_address_reproducible(self) -> None:
+        a = address_record(rng=random.Random(9))
+        b = address_record(rng=random.Random(9))
+        assert a == b


### PR DESCRIPTION
## Summary

Stage 4 (v1.4.0): provenance, ZWNJ hygiene, and address generation.

- `DATA_PROVENANCE.md` — source status, rebuild pipeline, pool sizes by release, CI gates
- `normalize_zwnj` / `apply_zwnj_policy` wired into `precision_repair`
- Address: `iranian_cities`, `city_name`, `street_name`, `address_record`
- `profile()` / `profile_record` now include `city`, `street`, `alley`, `plaque`

## Verification

- 167 tests passed locally
- Coverage 94.1%
- Pool sizes unchanged after ZWNJ pass (7493 / 3648 / 5748)